### PR TITLE
test(server): improve e2e coverage for bid selection, relay failure, and invalid payloads

### DIFF
--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -35,12 +35,7 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	const numRelays = 2
 	relayTimeout := 500 * time.Millisecond
 	backend := newTestBackend(t, numRelays, relayTimeout)
-	defer func() {
-		backend.relays[0].Server.Close()
-		if backend.relays[1].Server != nil {
-			backend.relays[1].Server.Close()
-		}
-	}()
+	defer closeServers(backend.relays)
 
 	fastRelay := backend.relays[0]
 	slowRelay := backend.relays[1]
@@ -122,4 +117,10 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 		require.Equal(t, http.StatusBadGateway, resp2.Code)
 		require.Contains(t, strings.ToLower(resp2.Body.String()), "no successful relay response")
 	})
+}
+
+func closeServers(relays []*mock.Relay) {
+	for _, relay := range relays {
+		relay.Server.Close()
+	}
 }

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -64,13 +64,17 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	fastRelay := backend.relays[0]
 	slowRelay := backend.relays[1]
 
+	// Simulate two relays: fast but low-value, and slow but high-value.
 	fastRelay.ResponseDelay = 0
 	slowRelay.ResponseDelay = 300 * time.Millisecond
 
+	// Assign bid values: fastRelay bids low, slowRelay bids high.
 	fastRelay.GetHeaderResponse = fastRelay.MakeGetHeaderResponse(1_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 	slowRelay.GetHeaderResponse = slowRelay.MakeGetHeaderResponse(10_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 
 	t.Run("RequestBuilderBids", func(t *testing.T) {
+		// Check that MEV-Boost correctly selects the highest bid from slowRelay,
+		// even though it responds later than fastRelay.
 		bid := setupBasicRequest(t, backend)
 		expected := uint256.NewInt(10_000_000_000)
 		actual := bid.Electra.Message.Value
@@ -78,6 +82,10 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	})
 
 	t.Run("SimulateBuilderFailure", func(t *testing.T) {
+		// Simulate a crash or disconnect of the selected (slow) relay
+		// before the validator sends a signed payload. This should
+		// result in a 502 error, confirming that MEV-Boost does not fall back
+		// to non-winning relays for getPayload.
 		header := fastRelay.GetHeaderResponse.Electra.Message.Header
 		blockHash := mock.HexToHash("0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46")
 
@@ -104,6 +112,9 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 	bid := setupBasicRequest(t, backend)
 
 	t.Run("TamperExecutionPayloadHeader", func(t *testing.T) {
+		// Tamper with the execution header after receiving the bid,
+		// e.g., changing the blockHash. This simulates a malicious or buggy validator.
+		// MEV-Boost should reject this signed block due to cache miss.
 		tampered := *bid.Electra.Message.Header
 		tampered.BlockHash = mock.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 
@@ -119,7 +130,12 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 	})
 
 	t.Run("EmptySignature", func(t *testing.T) {
+		// Simulate a payload with a missing validator signature.
+		// The relay should reject this with a 400 response,
+		// and MEV-Boost should translate that into a 502 response.
 		signed := createSignedBlindedBlock(bid.Electra.Message.Header, mock.HexToHash(testBlockHash), testSlot, "")
+
+		// Override mock relay handler to simulate signature verification failure.
 		// Validate the signature
 		// https://github.com/flashbots/mev-boost-relay/blob/fdb359fa6b6a7f96d37fb1f8cabb02c3868f965f/services/api/service.go#L654-L660
 		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {
@@ -144,7 +160,7 @@ func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
 
 	relay := backend.relays[0]
 	parentHash := mock.HexToHash(testBlockHash)
-	slotMismatch := testSlot + 1
+	slotMismatch := testSlot + 1 // simulate slot skew or delay
 
 	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
 		10_000_000_000,
@@ -154,6 +170,9 @@ func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
 		spec.DataVersionElectra,
 	)
 
+	// Request bid for testSlot, but send block for testSlot+1.
+	// This mismatch should result in MEV-Boost rejecting the payload
+	// because the slot is part of the cache key and doesn't match.
 	bid := setupBasicRequest(t, backend)
 	signedBlindedBlock := createSignedBlindedBlock(bid.Electra.Message.Header, parentHash, slotMismatch, testSig)
 

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -119,6 +119,132 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	})
 }
 
+func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
+	const (
+		blockHashStr  = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
+		parentHashStr = blockHashStr
+		pubKeyStr     = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+		numRelays     = 1
+	)
+	relayTimeout := 500 * time.Millisecond
+	backend := newTestBackend(t, numRelays, relayTimeout)
+	defer closeServers(backend.relays)
+
+	relay := backend.relays[0]
+
+	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
+		10_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
+	)
+
+	slot := uint64(12345)
+	parentHash := mock.HexToHash(parentHashStr)
+	pubkey := mock.HexToPubkey(pubKeyStr)
+	path := getHeaderPath(slot, parentHash, pubkey)
+
+	header := make(http.Header)
+	header.Set(HeaderAccept, MediaTypeJSON)
+
+	resp := backend.request(t, http.MethodGet, path, header, nil)
+	require.Equal(t, http.StatusOK, resp.Code, "getHeader failed")
+
+	bidResp := new(builderSpec.VersionedSignedBuilderBid)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp))
+
+	t.Run("TamperExecutionPayloadHeader", func(t *testing.T) {
+		// Tamper the execution header: change the block hash
+		tamperedHeader := *(bidResp.Electra.Message.Header)
+		tamperedHeader.BlockHash = mock.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+		signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
+			Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
+			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
+				Slot:          phase0.Slot(slot),
+				ProposerIndex: 1,
+				ParentRoot:    phase0.Root(parentHash),
+				StateRoot:     phase0.Root{0x01},
+				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
+					RANDAOReveal: phase0.BLSSignature{0xff},
+					ETH1Data: &phase0.ETH1Data{
+						BlockHash: tamperedHeader.BlockHash[:],
+					},
+					Graffiti: phase0.Hash32{0xab},
+					SyncAggregate: &altair.SyncAggregate{
+						SyncCommitteeBits: bitfield.NewBitvector512(),
+					},
+					ProposerSlashings:      []*phase0.ProposerSlashing{},
+					Deposits:               []*phase0.Deposit{},
+					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
+					ExecutionPayloadHeader: &tamperedHeader,
+					AttesterSlashings:      []*electra.AttesterSlashing{},
+					Attestations:           []*electra.Attestation{},
+					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
+					BlobKZGCommitments:     []deneb.KZGCommitment{},
+					ExecutionRequests:      &electra.ExecutionRequests{},
+				},
+			},
+		}
+		relay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
+
+		reqHeader := http.Header{}
+		reqHeader.Set("Content-Type", "application/json")
+		resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+
+		require.Equal(t, http.StatusBadGateway, resp2.Code,
+			"expected 502 since no relay matched tampered block hash")
+		require.Contains(t, resp2.Body.String(), "no successful relay response")
+	})
+
+	t.Run("EmptySignature", func(t *testing.T) {
+		signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
+			Signature: phase0.BLSSignature{},
+			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
+				Slot:          phase0.Slot(slot),
+				ProposerIndex: 1,
+				ParentRoot:    phase0.Root(parentHash),
+				StateRoot:     phase0.Root{0x01},
+				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
+					RANDAOReveal: phase0.BLSSignature{0xff},
+					ETH1Data: &phase0.ETH1Data{
+						BlockHash: bidResp.Electra.Message.Header.BlockHash[:],
+					},
+					Graffiti: phase0.Hash32{0xab},
+					SyncAggregate: &altair.SyncAggregate{
+						SyncCommitteeBits: bitfield.NewBitvector512(),
+					},
+					ProposerSlashings:      []*phase0.ProposerSlashing{},
+					Deposits:               []*phase0.Deposit{},
+					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
+					ExecutionPayloadHeader: bidResp.Electra.Message.Header,
+					AttesterSlashings:      []*electra.AttesterSlashing{},
+					Attestations:           []*electra.Attestation{},
+					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
+					BlobKZGCommitments:     []deneb.KZGCommitment{},
+					ExecutionRequests:      &electra.ExecutionRequests{},
+				},
+			},
+		}
+
+		// Validate the signature
+		// https://github.com/flashbots/mev-boost-relay/blob/fdb359fa6b6a7f96d37fb1f8cabb02c3868f965f/services/api/service.go#L654-L660
+		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", MediaTypeJSON)
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err := w.Write([]byte(`{"code": 400, "message": "could not verify payload signature"}`)); err != nil {
+				t.Fatalf("failed to write response: %v", err)
+			}
+		})
+
+		reqHeader := http.Header{}
+		reqHeader.Set("Content-Type", "application/json")
+		resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+
+		require.Equal(t, http.StatusBadGateway, resp2.Code,
+			"expected 502 since retry limit reached")
+		// TODO: Consider improving the error handling in the relay to return a more specific error after retrying
+		require.Contains(t, resp2.Body.String(), "could not verify payload signature")
+	})
+}
+
 func closeServers(relays []*mock.Relay) {
 	for _, relay := range relays {
 		relay.Server.Close()

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -118,13 +118,6 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 
 	t.Run("EmptySignature", func(t *testing.T) {
 		signed := createSignedBlindedBlock(bid.Electra.Message.Header, mock.HexToHash(testBlockHash), testSlot, "")
-		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", MediaTypeJSON)
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(`{"code": 400, "message": "could not verify payload signature"}`)); err != nil {
-				t.Fatalf("failed to write response: %v", err)
-			}
-		})
 		// Validate the signature
 		// https://github.com/flashbots/mev-boost-relay/blob/fdb359fa6b6a7f96d37fb1f8cabb02c3868f965f/services/api/service.go#L654-L660
 		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -24,15 +24,14 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
-const (
-	blockHashStr       = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
-	parentHashStr      = blockHashStr
-	pubKeyStr          = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
-	simulatedBlockHash = "0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46"
-)
-
 func TestMultiRelayPayloadFallback(t *testing.T) {
-	const numRelays = 2
+	const (
+		blockHashStr       = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
+		parentHashStr      = blockHashStr
+		pubKeyStr          = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+		simulatedBlockHash = "0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46"
+		numRelays          = 2
+	)
 	relayTimeout := 500 * time.Millisecond
 	backend := newTestBackend(t, numRelays, relayTimeout)
 	defer closeServers(backend.relays)

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -33,7 +33,9 @@ func setupTestBackend(t *testing.T, relays int, timeout time.Duration) (*testBac
 	t.Helper()
 	backend := newTestBackend(t, relays, timeout)
 	cleanup := func() {
-		closeServers(backend.relays)
+		for _, relay := range backend.relays {
+			relay.Server.Close()
+		}
 	}
 	return backend, cleanup
 }
@@ -195,11 +197,5 @@ func createSignedBlindedBlock(header *deneb.ExecutionPayloadHeader, blockHash ph
 				ExecutionRequests:      &electra.ExecutionRequests{},
 			},
 		},
-	}
-}
-
-func closeServers(relays []*mock.Relay) {
-	for _, relay := range relays {
-		relay.Server.Close()
 	}
 }

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -57,6 +57,35 @@ func setupBasicRequest(t *testing.T, backend *testBackend) *builderSpec.Versione
 	return bid
 }
 
+func TestSuccessfulSignedBlindedBlock(t *testing.T) {
+	backend, cleanup := setupTestBackend(t, 1, 500*time.Millisecond)
+	defer cleanup()
+
+	relay := backend.relays[0]
+
+	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
+		10_000_000_000,
+		testBlockHash,
+		testBlockHash,
+		testPubKey,
+		spec.DataVersionElectra,
+	)
+
+	bid := setupBasicRequest(t, backend)
+
+	blockHash := mock.HexToHash(testBlockHash)
+	signed := createSignedBlindedBlock(bid.Electra.Message.Header, blockHash, testSlot, testSig)
+
+	relay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
+
+	reqHeader := http.Header{}
+	reqHeader.Set("Content-Type", "application/json")
+	resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+
+	require.Equal(t, http.StatusOK, resp.Code, "expected success from relay")
+	require.Contains(t, strings.ToLower(resp.Body.String()), `"blockHash":"`+testBlockHash, "payload body missing expected blockHash")
+}
+
 func TestMultiRelayPayloadFallback(t *testing.T) {
 	backend, cleanup := setupTestBackend(t, 2, 500*time.Millisecond)
 	defer cleanup()

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -81,13 +81,13 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 		header := fastRelay.GetHeaderResponse.Electra.Message.Header
 		blockHash := mock.HexToHash("0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46")
 
-		signed := createSignedBlindedBlock(header, blockHash, testSlot, testSig)
-		slowRelay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
+		signedBlindedBlock := createSignedBlindedBlock(header, blockHash, testSlot, testSig)
+		slowRelay.GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBlock)
 		slowRelay.Server.Close()
 
 		reqHeader := http.Header{}
 		reqHeader.Set("Content-Type", "application/json")
-		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signedBlindedBlock)
 
 		require.Equal(t, http.StatusBadGateway, resp.Code)
 		require.Contains(t, strings.ToLower(resp.Body.String()), "no successful relay response")
@@ -107,12 +107,12 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 		tampered := *bid.Electra.Message.Header
 		tampered.BlockHash = mock.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 
-		signed := createSignedBlindedBlock(&tampered, tampered.BlockHash, testSlot, testSig)
-		relay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
+		signedBlindedBlock := createSignedBlindedBlock(&tampered, tampered.BlockHash, testSlot, testSig)
+		relay.GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBlock)
 
 		reqHeader := http.Header{}
 		reqHeader.Set("Content-Type", "application/json")
-		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signedBlindedBlock)
 
 		require.Equal(t, http.StatusBadGateway, resp.Code)
 		require.Contains(t, resp.Body.String(), "no successful relay response")
@@ -155,11 +155,11 @@ func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
 	)
 
 	bid := setupBasicRequest(t, backend)
-	signed := createSignedBlindedBlock(bid.Electra.Message.Header, parentHash, slotMismatch, testSig)
+	signedBlindedBlock := createSignedBlindedBlock(bid.Electra.Message.Header, parentHash, slotMismatch, testSig)
 
 	reqHeader := http.Header{}
 	reqHeader.Set("Content-Type", "application/json")
-	resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+	resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signedBlindedBlock)
 
 	require.Equal(t, http.StatusBadGateway, resp.Code)
 	require.Contains(t, strings.ToLower(resp.Body.String()), "no successful relay response")

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -7,20 +7,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/attestantio/go-eth2-client/spec"
-	"github.com/flashbots/mev-boost/server/mock"
-	"github.com/flashbots/mev-boost/server/params"
-	"github.com/holiman/uint256"
-	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/stretchr/testify/require"
-
 	builderSpec "github.com/attestantio/go-builder-client/spec"
 	eth2ApiV1Electra "github.com/attestantio/go-eth2-client/api/v1/electra"
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
 	"github.com/attestantio/go-eth2-client/spec/electra"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/flashbots/mev-boost/server/mock"
+	"github.com/flashbots/mev-boost/server/params"
+	"github.com/holiman/uint256"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -31,6 +30,7 @@ const (
 )
 
 func setupTestBackend(t *testing.T, relays int, timeout time.Duration) (*testBackend, func()) {
+	t.Helper()
 	backend := newTestBackend(t, relays, timeout)
 	cleanup := func() {
 		closeServers(backend.relays)
@@ -38,7 +38,8 @@ func setupTestBackend(t *testing.T, relays int, timeout time.Duration) (*testBac
 	return backend, cleanup
 }
 
-func setupBasicRequest(backend *testBackend, t *testing.T) *builderSpec.VersionedSignedBuilderBid {
+func setupBasicRequest(t *testing.T, backend *testBackend) *builderSpec.VersionedSignedBuilderBid {
+	t.Helper()
 	pubkey := mock.HexToPubkey(testPubKey)
 	parentHash := mock.HexToHash(testBlockHash)
 	path := getHeaderPath(testSlot, parentHash, pubkey)
@@ -68,7 +69,7 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	slowRelay.GetHeaderResponse = slowRelay.MakeGetHeaderResponse(10_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 
 	t.Run("RequestBuilderBids", func(t *testing.T) {
-		bid := setupBasicRequest(backend, t)
+		bid := setupBasicRequest(t, backend)
 		expected := uint256.NewInt(10_000_000_000)
 		actual := bid.Electra.Message.Value
 		require.Zero(t, actual.Cmp(expected), "expected highest bid %s, got %s", expected, actual)
@@ -98,7 +99,7 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 	relay := backend.relays[0]
 	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(10_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 
-	bid := setupBasicRequest(backend, t)
+	bid := setupBasicRequest(t, backend)
 
 	t.Run("TamperExecutionPayloadHeader", func(t *testing.T) {
 		tampered := *bid.Electra.Message.Header
@@ -158,7 +159,7 @@ func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
 		spec.DataVersionElectra,
 	)
 
-	bid := setupBasicRequest(backend, t)
+	bid := setupBasicRequest(t, backend)
 	signed := createSignedBlindedBlock(bid.Electra.Message.Header, parentHash, slotMismatch, testSig)
 
 	reqHeader := http.Header{}

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -104,6 +104,7 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 				},
 			},
 		}
+		slowRelay.GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBlock)
 
 		// Simulate failure of the winning relay before payload request
 		slowRelay.Server.Close()

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -16,7 +16,6 @@ import (
 
 	builderSpec "github.com/attestantio/go-builder-client/spec"
 	eth2ApiV1Electra "github.com/attestantio/go-eth2-client/api/v1/electra"
-
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
@@ -24,17 +23,40 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
+const (
+	testBlockHash = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
+	testPubKey    = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+	testSlot      = uint64(12345)
+	testSig       = "0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"
+)
+
+func setupTestBackend(t *testing.T, relays int, timeout time.Duration) (*testBackend, func()) {
+	backend := newTestBackend(t, relays, timeout)
+	cleanup := func() {
+		closeServers(backend.relays)
+	}
+	return backend, cleanup
+}
+
+func setupBasicRequest(backend *testBackend, t *testing.T) *builderSpec.VersionedSignedBuilderBid {
+	pubkey := mock.HexToPubkey(testPubKey)
+	parentHash := mock.HexToHash(testBlockHash)
+	path := getHeaderPath(testSlot, parentHash, pubkey)
+	header := http.Header{}
+	header.Set(HeaderAccept, MediaTypeJSON)
+
+	resp := backend.request(t, http.MethodGet, path, header, nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	bid := new(builderSpec.VersionedSignedBuilderBid)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), bid))
+
+	return bid
+}
+
 func TestMultiRelayPayloadFallback(t *testing.T) {
-	const (
-		blockHashStr       = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
-		parentHashStr      = blockHashStr
-		pubKeyStr          = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
-		simulatedBlockHash = "0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46"
-		numRelays          = 2
-	)
-	relayTimeout := 500 * time.Millisecond
-	backend := newTestBackend(t, numRelays, relayTimeout)
-	defer closeServers(backend.relays)
+	backend, cleanup := setupTestBackend(t, 2, 500*time.Millisecond)
+	defer cleanup()
 
 	fastRelay := backend.relays[0]
 	slowRelay := backend.relays[1]
@@ -42,188 +64,66 @@ func TestMultiRelayPayloadFallback(t *testing.T) {
 	fastRelay.ResponseDelay = 0
 	slowRelay.ResponseDelay = 300 * time.Millisecond
 
-	fastRelay.GetHeaderResponse = fastRelay.MakeGetHeaderResponse(
-		1_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
-	)
-	slowRelay.GetHeaderResponse = slowRelay.MakeGetHeaderResponse(
-		10_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
-	)
-
-	slot := uint64(12345)
-	parentHash := mock.HexToHash(parentHashStr)
-	pubkey := mock.HexToPubkey(pubKeyStr)
-	path := getHeaderPath(slot, parentHash, pubkey)
+	fastRelay.GetHeaderResponse = fastRelay.MakeGetHeaderResponse(1_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
+	slowRelay.GetHeaderResponse = slowRelay.MakeGetHeaderResponse(10_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 
 	t.Run("RequestBuilderBids", func(t *testing.T) {
-		header := make(http.Header)
-		header.Set(HeaderAccept, MediaTypeJSON)
-
-		resp := backend.request(t, http.MethodGet, path, header, nil)
-		require.Equal(t, http.StatusOK, resp.Code, "getHeader request failed: %v", resp.Body.String())
-
-		bidResp := new(builderSpec.VersionedSignedBuilderBid)
-		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp), "Failed to parse getHeader response")
-
-		expectedHigh := uint256.NewInt(10_000_000_000)
-		actualBid := bidResp.Electra.Message.Value
-		require.Zero(t, actualBid.Cmp(expectedHigh),
-			"expected highest bid %s, got %s", expectedHigh, actualBid)
+		bid := setupBasicRequest(backend, t)
+		expected := uint256.NewInt(10_000_000_000)
+		actual := bid.Electra.Message.Value
+		require.Zero(t, actual.Cmp(expected), "expected highest bid %s, got %s", expected, actual)
 	})
 
 	t.Run("SimulateBuilderFailure", func(t *testing.T) {
-		slot := uint64(12345)
-		headerObj := fastRelay.GetHeaderResponse.Electra.Message.Header
-		blockHash := mock.HexToHash(simulatedBlockHash)
+		header := fastRelay.GetHeaderResponse.Electra.Message.Header
+		blockHash := mock.HexToHash("0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46")
 
-		signedBlindedBlock := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
-			Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
-			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
-				Slot:          phase0.Slot(slot),
-				ProposerIndex: 1,
-				ParentRoot:    phase0.Root(parentHash),
-				StateRoot:     phase0.Root{0x02},
-				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
-					RANDAOReveal: phase0.BLSSignature{0xa1},
-					ETH1Data: &phase0.ETH1Data{
-						BlockHash: blockHash[:],
-					},
-					Graffiti: phase0.Hash32{0xa2},
-					SyncAggregate: &altair.SyncAggregate{
-						SyncCommitteeBits: bitfield.NewBitvector512(),
-					},
-					ProposerSlashings:      []*phase0.ProposerSlashing{},
-					Deposits:               []*phase0.Deposit{},
-					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
-					ExecutionPayloadHeader: headerObj,
-					AttesterSlashings:      []*electra.AttesterSlashing{},
-					Attestations:           []*electra.Attestation{},
-					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
-					BlobKZGCommitments:     []deneb.KZGCommitment{},
-					ExecutionRequests:      &electra.ExecutionRequests{},
-				},
-			},
-		}
-		slowRelay.GetPayloadResponse = blindedBlockToBlockResponse(signedBlindedBlock)
-
-		// Simulate failure of the winning relay before payload request
+		signed := createSignedBlindedBlock(header, blockHash, testSlot, testSig)
+		slowRelay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
 		slowRelay.Server.Close()
 
 		reqHeader := http.Header{}
 		reqHeader.Set("Content-Type", "application/json")
-		payloadPath := params.PathGetPayload
-		resp2 := backend.request(t, http.MethodPost, payloadPath, reqHeader, signedBlindedBlock)
+		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
 
-		// Expect aggregator to return error since builder (relay) is unreachable
-		require.Equal(t, http.StatusBadGateway, resp2.Code)
-		require.Contains(t, strings.ToLower(resp2.Body.String()), "no successful relay response")
+		require.Equal(t, http.StatusBadGateway, resp.Code)
+		require.Contains(t, strings.ToLower(resp.Body.String()), "no successful relay response")
 	})
 }
 
 func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
-	const (
-		blockHashStr  = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
-		parentHashStr = blockHashStr
-		pubKeyStr     = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
-		numRelays     = 1
-	)
-	relayTimeout := 500 * time.Millisecond
-	backend := newTestBackend(t, numRelays, relayTimeout)
-	defer closeServers(backend.relays)
+	backend, cleanup := setupTestBackend(t, 1, 500*time.Millisecond)
+	defer cleanup()
 
 	relay := backend.relays[0]
+	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(10_000_000_000, testBlockHash, testBlockHash, testPubKey, spec.DataVersionElectra)
 
-	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
-		10_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
-	)
-
-	slot := uint64(12345)
-	parentHash := mock.HexToHash(parentHashStr)
-	pubkey := mock.HexToPubkey(pubKeyStr)
-	path := getHeaderPath(slot, parentHash, pubkey)
-
-	header := make(http.Header)
-	header.Set(HeaderAccept, MediaTypeJSON)
-
-	resp := backend.request(t, http.MethodGet, path, header, nil)
-	require.Equal(t, http.StatusOK, resp.Code, "getHeader failed")
-
-	bidResp := new(builderSpec.VersionedSignedBuilderBid)
-	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp))
+	bid := setupBasicRequest(backend, t)
 
 	t.Run("TamperExecutionPayloadHeader", func(t *testing.T) {
-		// Tamper the execution header: change the block hash
-		tamperedHeader := *(bidResp.Electra.Message.Header)
-		tamperedHeader.BlockHash = mock.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		tampered := *bid.Electra.Message.Header
+		tampered.BlockHash = mock.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 
-		signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
-			Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
-			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
-				Slot:          phase0.Slot(slot),
-				ProposerIndex: 1,
-				ParentRoot:    phase0.Root(parentHash),
-				StateRoot:     phase0.Root{0x01},
-				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
-					RANDAOReveal: phase0.BLSSignature{0xff},
-					ETH1Data: &phase0.ETH1Data{
-						BlockHash: tamperedHeader.BlockHash[:],
-					},
-					Graffiti: phase0.Hash32{0xab},
-					SyncAggregate: &altair.SyncAggregate{
-						SyncCommitteeBits: bitfield.NewBitvector512(),
-					},
-					ProposerSlashings:      []*phase0.ProposerSlashing{},
-					Deposits:               []*phase0.Deposit{},
-					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
-					ExecutionPayloadHeader: &tamperedHeader,
-					AttesterSlashings:      []*electra.AttesterSlashing{},
-					Attestations:           []*electra.Attestation{},
-					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
-					BlobKZGCommitments:     []deneb.KZGCommitment{},
-					ExecutionRequests:      &electra.ExecutionRequests{},
-				},
-			},
-		}
+		signed := createSignedBlindedBlock(&tampered, tampered.BlockHash, testSlot, testSig)
 		relay.GetPayloadResponse = blindedBlockToBlockResponse(signed)
 
 		reqHeader := http.Header{}
 		reqHeader.Set("Content-Type", "application/json")
-		resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
 
-		require.Equal(t, http.StatusBadGateway, resp2.Code,
-			"expected 502 since no relay matched tampered block hash")
-		require.Contains(t, resp2.Body.String(), "no successful relay response")
+		require.Equal(t, http.StatusBadGateway, resp.Code)
+		require.Contains(t, resp.Body.String(), "no successful relay response")
 	})
 
 	t.Run("EmptySignature", func(t *testing.T) {
-		signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
-			Signature: phase0.BLSSignature{},
-			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
-				Slot:          phase0.Slot(slot),
-				ProposerIndex: 1,
-				ParentRoot:    phase0.Root(parentHash),
-				StateRoot:     phase0.Root{0x01},
-				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
-					RANDAOReveal: phase0.BLSSignature{0xff},
-					ETH1Data: &phase0.ETH1Data{
-						BlockHash: bidResp.Electra.Message.Header.BlockHash[:],
-					},
-					Graffiti: phase0.Hash32{0xab},
-					SyncAggregate: &altair.SyncAggregate{
-						SyncCommitteeBits: bitfield.NewBitvector512(),
-					},
-					ProposerSlashings:      []*phase0.ProposerSlashing{},
-					Deposits:               []*phase0.Deposit{},
-					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
-					ExecutionPayloadHeader: bidResp.Electra.Message.Header,
-					AttesterSlashings:      []*electra.AttesterSlashing{},
-					Attestations:           []*electra.Attestation{},
-					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
-					BlobKZGCommitments:     []deneb.KZGCommitment{},
-					ExecutionRequests:      &electra.ExecutionRequests{},
-				},
-			},
-		}
-
+		signed := createSignedBlindedBlock(bid.Electra.Message.Header, mock.HexToHash(testBlockHash), testSlot, "")
+		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", MediaTypeJSON)
+			w.WriteHeader(http.StatusBadRequest)
+			if _, err := w.Write([]byte(`{"code": 400, "message": "could not verify payload signature"}`)); err != nil {
+				t.Fatalf("failed to write response: %v", err)
+			}
+		})
 		// Validate the signature
 		// https://github.com/flashbots/mev-boost-relay/blob/fdb359fa6b6a7f96d37fb1f8cabb02c3868f965f/services/api/service.go#L654-L660
 		relay.OverrideHandleGetPayload(func(w http.ResponseWriter, _ *http.Request) {
@@ -236,69 +136,64 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 
 		reqHeader := http.Header{}
 		reqHeader.Set("Content-Type", "application/json")
-		resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+		resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
 
-		require.Equal(t, http.StatusBadGateway, resp2.Code,
-			"expected 502 since retry limit reached")
-		// TODO: Consider improving the error handling in the relay to return a more specific error after retrying
-		require.Contains(t, resp2.Body.String(), "could not verify payload signature")
+		require.Equal(t, http.StatusBadGateway, resp.Code)
 	})
 }
 
 func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
-	const (
-		parentHashStr = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
-		pubKeyStr     = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
-		numRelays     = 1
-	)
-	relayTimeout := 500 * time.Millisecond
-	backend := newTestBackend(t, numRelays, relayTimeout)
-	defer closeServers(backend.relays)
+	backend, cleanup := setupTestBackend(t, 1, 500*time.Millisecond)
+	defer cleanup()
 
 	relay := backend.relays[0]
-
-	slot := uint64(12345)
-	slotMismatch := slot + 1
-	parentHash := mock.HexToHash(parentHashStr)
-	pubkey := mock.HexToPubkey(pubKeyStr)
+	parentHash := mock.HexToHash(testBlockHash)
+	slotMismatch := testSlot + 1
 
 	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
 		10_000_000_000,
 		parentHash.String(),
 		parentHash.String(),
-		pubKeyStr,
+		testPubKey,
 		spec.DataVersionElectra,
 	)
 
-	path := getHeaderPath(slot, parentHash, pubkey)
-	header := http.Header{}
-	header.Set(HeaderAccept, MediaTypeJSON)
-	resp := backend.request(t, http.MethodGet, path, header, nil)
-	require.Equal(t, http.StatusOK, resp.Code)
+	bid := setupBasicRequest(backend, t)
+	signed := createSignedBlindedBlock(bid.Electra.Message.Header, parentHash, slotMismatch, testSig)
 
-	bidResp := new(builderSpec.VersionedSignedBuilderBid)
-	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp))
+	reqHeader := http.Header{}
+	reqHeader.Set("Content-Type", "application/json")
+	resp := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
 
-	signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
-		Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
+	require.Equal(t, http.StatusBadGateway, resp.Code)
+	require.Contains(t, strings.ToLower(resp.Body.String()), "no successful relay response")
+}
+
+func createSignedBlindedBlock(header *deneb.ExecutionPayloadHeader, blockHash phase0.Hash32, slot uint64, hexSig string) *eth2ApiV1Electra.SignedBlindedBeaconBlock {
+	sig := phase0.BLSSignature{}
+	if hexSig != "" {
+		sig = mock.HexToSignature(hexSig)
+	}
+	return &eth2ApiV1Electra.SignedBlindedBeaconBlock{
+		Signature: sig,
 		Message: &eth2ApiV1Electra.BlindedBeaconBlock{
-			Slot:          phase0.Slot(slotMismatch), // different slot
+			Slot:          phase0.Slot(slot),
 			ProposerIndex: 1,
-			ParentRoot:    phase0.Root(parentHash),
+			ParentRoot:    phase0.Root(blockHash),
 			StateRoot:     phase0.Root{0x01},
 			Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
-				RANDAOReveal: phase0.BLSSignature{0xee},
+				RANDAOReveal: phase0.BLSSignature{0xaa},
 				ETH1Data: &phase0.ETH1Data{
-					BlockHash: bidResp.Electra.Message.Header.BlockHash[:],
+					BlockHash: blockHash[:],
 				},
-				Graffiti: phase0.Hash32{0xcd},
+				Graffiti: phase0.Hash32{0xbb},
 				SyncAggregate: &altair.SyncAggregate{
 					SyncCommitteeBits: bitfield.NewBitvector512(),
 				},
 				ProposerSlashings:      []*phase0.ProposerSlashing{},
 				Deposits:               []*phase0.Deposit{},
 				VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
-				ExecutionPayloadHeader: bidResp.Electra.Message.Header,
+				ExecutionPayloadHeader: header,
 				AttesterSlashings:      []*electra.AttesterSlashing{},
 				Attestations:           []*electra.Attestation{},
 				BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
@@ -307,14 +202,6 @@ func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
 			},
 		},
 	}
-
-	reqHeader := http.Header{}
-	reqHeader.Set("Content-Type", "application/json")
-	resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
-
-	require.Equal(t, http.StatusBadGateway, resp2.Code,
-		"expected 502 since MEV-Boost had no cached bid for slot %d", slotMismatch)
-	require.Contains(t, strings.ToLower(resp2.Body.String()), "no successful relay response")
 }
 
 func closeServers(relays []*mock.Relay) {

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/flashbots/mev-boost/server/mock"
+	"github.com/flashbots/mev-boost/server/params"
+	"github.com/holiman/uint256"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/stretchr/testify/require"
+
+	builderSpec "github.com/attestantio/go-builder-client/spec"
+	eth2ApiV1Electra "github.com/attestantio/go-eth2-client/api/v1/electra"
+
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/electra"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+const (
+	blockHashStr       = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
+	parentHashStr      = blockHashStr
+	pubKeyStr          = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+	simulatedBlockHash = "0x534809bd2b6832edff8d8ce4cb0e50068804fd1ef432c8362ad708a74fdc0e46"
+)
+
+func TestMultiRelayPayloadFallback(t *testing.T) {
+	const numRelays = 2
+	relayTimeout := 500 * time.Millisecond
+	backend := newTestBackend(t, numRelays, relayTimeout)
+	defer func() {
+		backend.relays[0].Server.Close()
+		if backend.relays[1].Server != nil {
+			backend.relays[1].Server.Close()
+		}
+	}()
+
+	fastRelay := backend.relays[0]
+	slowRelay := backend.relays[1]
+
+	fastRelay.ResponseDelay = 0
+	slowRelay.ResponseDelay = 300 * time.Millisecond
+
+	fastRelay.GetHeaderResponse = fastRelay.MakeGetHeaderResponse(
+		1_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
+	)
+	slowRelay.GetHeaderResponse = slowRelay.MakeGetHeaderResponse(
+		10_000_000_000, blockHashStr, parentHashStr, pubKeyStr, spec.DataVersionElectra,
+	)
+
+	slot := uint64(12345)
+	parentHash := mock.HexToHash(parentHashStr)
+	pubkey := mock.HexToPubkey(pubKeyStr)
+	path := getHeaderPath(slot, parentHash, pubkey)
+
+	t.Run("RequestBuilderBids", func(t *testing.T) {
+		header := make(http.Header)
+		header.Set(HeaderAccept, MediaTypeJSON)
+
+		resp := backend.request(t, http.MethodGet, path, header, nil)
+		require.Equal(t, http.StatusOK, resp.Code, "getHeader request failed: %v", resp.Body.String())
+
+		bidResp := new(builderSpec.VersionedSignedBuilderBid)
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp), "Failed to parse getHeader response")
+
+		expectedHigh := uint256.NewInt(10_000_000_000)
+		actualBid := bidResp.Electra.Message.Value
+		require.Zero(t, actualBid.Cmp(expectedHigh),
+			"expected highest bid %s, got %s", expectedHigh, actualBid)
+	})
+
+	t.Run("SimulateBuilderFailure", func(t *testing.T) {
+		slot := uint64(12345)
+		headerObj := fastRelay.GetHeaderResponse.Electra.Message.Header
+		blockHash := mock.HexToHash(simulatedBlockHash)
+
+		signedBlindedBlock := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
+			Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
+			Message: &eth2ApiV1Electra.BlindedBeaconBlock{
+				Slot:          phase0.Slot(slot),
+				ProposerIndex: 1,
+				ParentRoot:    phase0.Root(parentHash),
+				StateRoot:     phase0.Root{0x02},
+				Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
+					RANDAOReveal: phase0.BLSSignature{0xa1},
+					ETH1Data: &phase0.ETH1Data{
+						BlockHash: blockHash[:],
+					},
+					Graffiti: phase0.Hash32{0xa2},
+					SyncAggregate: &altair.SyncAggregate{
+						SyncCommitteeBits: bitfield.NewBitvector512(),
+					},
+					ProposerSlashings:      []*phase0.ProposerSlashing{},
+					Deposits:               []*phase0.Deposit{},
+					VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
+					ExecutionPayloadHeader: headerObj,
+					AttesterSlashings:      []*electra.AttesterSlashing{},
+					Attestations:           []*electra.Attestation{},
+					BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
+					BlobKZGCommitments:     []deneb.KZGCommitment{},
+					ExecutionRequests:      &electra.ExecutionRequests{},
+				},
+			},
+		}
+
+		// Simulate failure of the winning relay before payload request
+		slowRelay.Server.Close()
+
+		reqHeader := http.Header{}
+		reqHeader.Set("Content-Type", "application/json")
+		payloadPath := params.PathGetPayload
+		resp2 := backend.request(t, http.MethodPost, payloadPath, reqHeader, signedBlindedBlock)
+
+		// Expect aggregator to return error since builder (relay) is unreachable
+		require.Equal(t, http.StatusBadGateway, resp2.Code)
+		require.Contains(t, strings.ToLower(resp2.Body.String()), "no successful relay response")
+	})
+}

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -245,6 +245,78 @@ func TestSemanticallyInvalidSignedBlindedBlock(t *testing.T) {
 	})
 }
 
+func TestSignedBlindedBlockWithSlotMismatch(t *testing.T) {
+	const (
+		parentHashStr = "0xe28385e7bd68df656cd0042b74b69c3104b5356ed1f20eb69f1f925df47a3ab7"
+		pubKeyStr     = "0x8a1d7b8dd64e0aafe7ea7b6c95065c9364cf99d38470c12ee807d55f7de1529ad29ce2c422e0b65e3d5a05c02caca249"
+		numRelays     = 1
+	)
+	relayTimeout := 500 * time.Millisecond
+	backend := newTestBackend(t, numRelays, relayTimeout)
+	defer closeServers(backend.relays)
+
+	relay := backend.relays[0]
+
+	slot := uint64(12345)
+	slotMismatch := slot + 1
+	parentHash := mock.HexToHash(parentHashStr)
+	pubkey := mock.HexToPubkey(pubKeyStr)
+
+	relay.GetHeaderResponse = relay.MakeGetHeaderResponse(
+		10_000_000_000,
+		parentHash.String(),
+		parentHash.String(),
+		pubKeyStr,
+		spec.DataVersionElectra,
+	)
+
+	path := getHeaderPath(slot, parentHash, pubkey)
+	header := http.Header{}
+	header.Set(HeaderAccept, MediaTypeJSON)
+	resp := backend.request(t, http.MethodGet, path, header, nil)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	bidResp := new(builderSpec.VersionedSignedBuilderBid)
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &bidResp))
+
+	signed := &eth2ApiV1Electra.SignedBlindedBeaconBlock{
+		Signature: mock.HexToSignature("0x8c795f751f812eabbabdee85100a06730a9904a4b53eedaa7f546fe0e23cd75125e293c6b0d007aa68a9da4441929d16072668abb4323bb04ac81862907357e09271fe414147b3669509d91d8ffae2ec9c789a5fcd4519629b8f2c7de8d0cce9"),
+		Message: &eth2ApiV1Electra.BlindedBeaconBlock{
+			Slot:          phase0.Slot(slotMismatch), // different slot
+			ProposerIndex: 1,
+			ParentRoot:    phase0.Root(parentHash),
+			StateRoot:     phase0.Root{0x01},
+			Body: &eth2ApiV1Electra.BlindedBeaconBlockBody{
+				RANDAOReveal: phase0.BLSSignature{0xee},
+				ETH1Data: &phase0.ETH1Data{
+					BlockHash: bidResp.Electra.Message.Header.BlockHash[:],
+				},
+				Graffiti: phase0.Hash32{0xcd},
+				SyncAggregate: &altair.SyncAggregate{
+					SyncCommitteeBits: bitfield.NewBitvector512(),
+				},
+				ProposerSlashings:      []*phase0.ProposerSlashing{},
+				Deposits:               []*phase0.Deposit{},
+				VoluntaryExits:         []*phase0.SignedVoluntaryExit{},
+				ExecutionPayloadHeader: bidResp.Electra.Message.Header,
+				AttesterSlashings:      []*electra.AttesterSlashing{},
+				Attestations:           []*electra.Attestation{},
+				BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
+				BlobKZGCommitments:     []deneb.KZGCommitment{},
+				ExecutionRequests:      &electra.ExecutionRequests{},
+			},
+		},
+	}
+
+	reqHeader := http.Header{}
+	reqHeader.Set("Content-Type", "application/json")
+	resp2 := backend.request(t, http.MethodPost, params.PathGetPayload, reqHeader, signed)
+
+	require.Equal(t, http.StatusBadGateway, resp2.Code,
+		"expected 502 since MEV-Boost had no cached bid for slot %d", slotMismatch)
+	require.Contains(t, strings.ToLower(resp2.Body.String()), "no successful relay response")
+}
+
 func closeServers(relays []*mock.Relay) {
 	for _, relay := range relays {
 		relay.Server.Close()


### PR DESCRIPTION
## 📝 Summary

This PR introduces end-to-end tests for critical scenarios in MEV-Boost's validator-relay interaction model. The changes target previously uncovered edge cases in the bid - payload request lifecycle, particularly in situations involving multiple relays, malformed payloads, and mismatches in slot

> [!NOTE]
> This PR may be easier to review per commit.

## ⛱ Motivation and Context

This PR was performed in the context of test work.

### Development Notes – Test Strategy & Thought Process

At the beginning of this task, I started by reviewing the existing test coverage in the `mev-boost` repository. I ran the coverage tools locally and considered extending test cases across different fork versions (Bellatrix, Capella, Deneb, Electra). However, after a closer look, I realised that doing so would result in relatively shallow or repetitive tests — and wouldn’t constitute a "meaningful improvement" as requested by the task. The logic across forks is largely duplicated and not where current gaps lie.

Next, I explored the idea of setting up a CI-based integration test pipeline using [`builder-playground`](https://github.com/flashbots/builder-playground). My goal was to create a test harness simulating full validator-relay-builder interaction flows. However, I quickly discovered that:

- Integration tests already exist,
- They use Kurtosis, which is explicitly noted in the task brief as not recommended due to slow iteration time,
- And setting up a reliable CI harness using this stack would far exceed the 10-hour time budget.

At that point, I changed direction and shifted my focus entirely to reading and analysing every test in the server package. This deep dive surfaced something far more impactful:

Certain real-world failure modes — particularly around bid cache handling, invalid payloads, and signature failures — were not covered, or only implicitly assumed in logic but not tested directly.

This observation shaped my final test strategy.

Rather than adding shallow fork permutations or overengineering infra, I chose to focus on high-value, realistic validator/relay edge cases that:

- Are critical to production safety,
- Reflect MEV-Boost's real role as a stateless bid router,
- And are currently untested in the local e2e test suite.

Each new test was designed to explicitly check behavior that would otherwise silently fail.

### Thoughts During Test Design

### `TestMultiRelayPayloadFallback`
#### What it tests:

- Bid selection from multiple relays with varying response times.
- Whether MEV-Boost correctly selects the highest bid, even if it arrives later than a lower one.
- Behavior when the selected (winning) relay fails before payload delivery.

#### Why it matters:

- This simulates a very realistic scenario: multiple relays race to offer bids, the validator waits to pick the most valuable one, and the relay that wins might go offline by the time the payload is requested.

#### What I learned while writing this:
Initially, I assumed MEV-Boost might retry another relay if the winning one fails. It does not — and this is by design. Bids are matched one-to-one for security and simplicity. If the chosen relay fails, Boost logs the error and returns a 502. This test proves that.

### `TestSemanticallyInvalidSignedBlindedBlock`

1. `TamperExecutionPayloadHeader`

#### What it tests:

- What happens when a validator tampers with the `ExecutionPayloadHeader` after receiving the header from the relay (e.g., changes `blockHash`).

#### Why it matters:

- In a malicious or misconfigured setup, a validator might attempt to fake a signed payload that doesn’t match the originally agreed bid.
- This is explicitly rejected by MEV-Boost: it can’t find a bid for the new blockHash → returns 502.

#### Key takeaway:

- MEV-Boost doesn’t “know” whether the payload is valid in the cryptographic sense.

It’s a stateless cache match — if `blockHash` doesn't match any stored bid → it must reject.

2. `EmptySignature`

#### What it tests:

- A validator sends a block with an empty BLS signature.

#### Why it matters:

- This case is subtly important. While MEV-Boost itself doesn’t validate BLS signatures, the relays do.
- If the relay rejects the request with a 400 Bad Request, Boost should detect that no relays succeeded and propagate a 502.

#### TODO:

- Consider improving error handling, i.e. return 400 Bad Request in this case.

### `TestSignedBlindedBlockWithSlotMismatch`
#### What it tests:

- Submitting a signed blinded block for slot N+1 after getting a bid for slot N.

#### Why it matters:

- In reality, validators might get delayed (clock drift, GC, load spike) and send the signed block slightly late.
- This test confirms that MEV-Boost does not perform any kind of match — slot numbers must match exactly.

## 📚 References

- https://docs.flashbots.net/flashbots-mev-boost/architecture-overview/block-proposal
- https://github.com/flashbots/mev-boost-relay/blob/fdb359fa6b6a7f96d37fb1f8cabb02c3868f965f/services/api/service.go#L654-L660

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test-race`
* [x] `go mod tidy`
